### PR TITLE
Add various properties for more versatile requests, add simple model change listener, fix critical bug in case of subsequential identical WS responses

### DIFF
--- a/JSONListModel/JSONListModel.qml
+++ b/JSONListModel/JSONListModel.qml
@@ -1,44 +1,59 @@
 /* JSONListModel - a QML ListModel with JSON and JSONPath support
- *
- * Copyright (c) 2012 Romain Pokrzywka (KDAB) (romain@kdab.com)
- * Licensed under the MIT licence (http://opensource.org/licenses/mit-license.php)
- */
+*
+* Copyright (c) 2012 Romain Pokrzywka (KDAB) (romain@kdab.com)
+* Licensed under the MIT licence (http://opensource.org/licenses/mit-license.php)
+*/
 
-import QtQuick 1.1
+import QtQuick 2.0
 import "jsonpath.js" as JSONPath
 
 Item {
     property string source: ""
+    property string contentType: ""
+    property string postData: ""
+    property string requestType: "GET"
     property string json: ""
     property string query: ""
+
+    property bool loading: false
+    property bool listModelUpdate: false
 
     property ListModel model : ListModel { id: jsonModel }
     property alias count: jsonModel.count
 
-    onSourceChanged: {
-        var xhr = new XMLHttpRequest;
-        xhr.open("GET", source);
-        xhr.onreadystatechange = function() {
-            if (xhr.readyState == XMLHttpRequest.DONE)
-                json = xhr.responseText;
-        }
-        xhr.send();
-    }
-
     onJsonChanged: updateJSONModel()
     onQueryChanged: updateJSONModel()
+
+    function refresh() {
+        loading = true;
+        var xhr = new XMLHttpRequest;
+        xhr.open(requestType, source);
+        if (contentType !== "")
+            xhr.setRequestHeader("Content-Type", contentType);
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState === XMLHttpRequest.DONE)
+                json = xhr.responseText;
+        }
+        xhr.send(postData);
+    }
 
     function updateJSONModel() {
         jsonModel.clear();
 
-        if ( json === "" )
+        if ( json === "") {
+            loading = false;
             return;
+        }
+
+        console.log(json);
 
         var objectArray = parseJSONString(json, query);
         for ( var key in objectArray ) {
             var jo = objectArray[key];
             jsonModel.append( jo );
         }
+        loading = false;
+        listModelUpdate = !listModelUpdate;
     }
 
     function parseJSONString(jsonString, jsonPathQuery) {

--- a/JSONListModel/JSONListModel.qml
+++ b/JSONListModel/JSONListModel.qml
@@ -21,25 +21,35 @@ Item {
     property ListModel model : ListModel { id: jsonModel }
     property alias count: jsonModel.count
 
-    onQueryChanged: updateJSONModel()
-
     function refresh() {
         loading = true;
         var xhr = new XMLHttpRequest;
+        console.log("Sending request to JSON API")
+        console.log("Request Type: "+requestType);
+        console.log("Source: "+source);
         xhr.open(requestType, source);
         if (contentType !== "")
             xhr.setRequestHeader("Content-Type", contentType);
         xhr.onreadystatechange = function() {
             if (xhr.readyState === XMLHttpRequest.DONE) {
+                console.log(xhr.responseText);
+                console.log(xhr.getAllResponseHeaders());
                 json = xhr.responseText;
                 updateJSONModel();
             }
         }
-        xhr.send(postData);
+        console.log("Post Data: "+postData)
+        if (requestType == "POST") {
+            xhr.send(postData);
+        } else {
+            xhr.send()
+        }
     }
 
     function updateJSONModel() {
-        jsonModel.clear();
+        if (jsonModel.count > 0) {
+            jsonModel.clear();
+        }
 
         if ( json === "") {
             loading = false;
@@ -51,7 +61,7 @@ Item {
         var objectArray = parseJSONString(json, query);
         for ( var key in objectArray ) {
             var jo = objectArray[key];
-            jsonModel.append( jo );
+            jsonModel.append(jo);
         }
         loading = false;
         listModelUpdate = !listModelUpdate;
@@ -63,5 +73,9 @@ Item {
             objectArray = JSONPath.jsonPath(objectArray, jsonPathQuery);
 
         return objectArray;
+    }
+
+    function clear() {
+        jsonModel.clear();
     }
 }

--- a/JSONListModel/JSONListModel.qml
+++ b/JSONListModel/JSONListModel.qml
@@ -21,7 +21,6 @@ Item {
     property ListModel model : ListModel { id: jsonModel }
     property alias count: jsonModel.count
 
-    onJsonChanged: updateJSONModel()
     onQueryChanged: updateJSONModel()
 
     function refresh() {
@@ -31,8 +30,10 @@ Item {
         if (contentType !== "")
             xhr.setRequestHeader("Content-Type", contentType);
         xhr.onreadystatechange = function() {
-            if (xhr.readyState === XMLHttpRequest.DONE)
+            if (xhr.readyState === XMLHttpRequest.DONE) {
                 json = xhr.responseText;
+                updateJSONModel();
+            }
         }
         xhr.send(postData);
     }


### PR DESCRIPTION
Add properties for requestType, POST data and content type. In combination with the new listModelUpdate property (which indicates whether the list model has updated, simply use by implementing onListModelUpdateChanged as onModelChanged never gets fired due to reusing the model object for all requests) and the loading property this enables implementation of rather versatile asynchronous requests. I've also removed the onSourceChanged observer and replaced it by an explicit refresh() function to allow changing of multiple request properties without accidentally triggering a request.
